### PR TITLE
Fix `ControlNeXtSDVModel` -> `ControlNeXtSVDModel` in SVD-related Codes

### DIFF
--- a/ControlNeXt-SVD-v2-Training/models/controlnext_vid_svd.py
+++ b/ControlNeXt-SVD-v2-Training/models/controlnext_vid_svd.py
@@ -9,7 +9,7 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.resnet import Downsample2D, ResnetBlock2D
 
 
-class ControlNeXtSDVModel(ModelMixin, ConfigMixin):
+class ControlNeXtSVDModel(ModelMixin, ConfigMixin):
     _supports_gradient_checkpointing = True
 
     @register_to_config

--- a/ControlNeXt-SVD-v2-Training/pipeline/pipeline_stable_video_diffusion_controlnext.py
+++ b/ControlNeXt-SVD-v2-Training/pipeline/pipeline_stable_video_diffusion_controlnext.py
@@ -20,7 +20,7 @@ import numpy as np
 import PIL.Image
 import torch
 from transformers import CLIPImageProcessor, CLIPVisionModelWithProjection
-from models.controlnext_vid_svd import ControlNeXtSDVModel
+from models.controlnext_vid_svd import ControlNeXtSVDModel
 
 from diffusers.image_processor import VaeImageProcessor
 from diffusers.models import AutoencoderKLTemporalDecoder, UNetSpatioTemporalConditionModel
@@ -125,7 +125,7 @@ class StableVideoDiffusionPipelineControlNeXt(DiffusionPipeline):
         vae: AutoencoderKLTemporalDecoder,
         image_encoder: CLIPVisionModelWithProjection,
         unet: UNetSpatioTemporalConditionControlNeXtModel,
-        controlnext: ControlNeXtSDVModel,
+        controlnext: ControlNeXtSVDModel,
         scheduler: EulerDiscreteScheduler,
         feature_extractor: CLIPImageProcessor,
     ):

--- a/ControlNeXt-SVD-v2-Training/train_svd.py
+++ b/ControlNeXt-SVD-v2-Training/train_svd.py
@@ -59,7 +59,7 @@ from utils.dataset import WebVid10M
 from utils.vid_dataset import UBCFashion
 from models.unet_spatio_temporal_condition_controlnext import UNetSpatioTemporalConditionControlNeXtModel
 from pipeline.pipeline_stable_video_diffusion_controlnext import StableVideoDiffusionPipelineControlNeXt
-from models.controlnext_vid_svd import ControlNeXtSDVModel
+from models.controlnext_vid_svd import ControlNeXtSVDModel
 import torch.nn as nn
 import pdb
 from diffusers.utils.torch_utils import randn_tensor
@@ -920,7 +920,7 @@ def main():
     )
     
     logger.info("Initializing controlnext weights from unet")
-    controlnext = ControlNeXtSDVModel()
+    controlnext = ControlNeXtSVDModel()
 
     if args.controlnet_model_name_or_path:
         logger.info("Loading existing controlnet weights")

--- a/ControlNeXt-SVD-v2/models/controlnext_vid_svd.py
+++ b/ControlNeXt-SVD-v2/models/controlnext_vid_svd.py
@@ -9,7 +9,7 @@ from diffusers.models.modeling_utils import ModelMixin
 from diffusers.models.resnet import Downsample2D, ResnetBlock2D
     
 
-class ControlNeXtSDVModel(ModelMixin, ConfigMixin):
+class ControlNeXtSVDModel(ModelMixin, ConfigMixin):
     _supports_gradient_checkpointing = True
 
     @register_to_config

--- a/ControlNeXt-SVD-v2/pipeline/pipeline_stable_video_diffusion_controlnext.py
+++ b/ControlNeXt-SVD-v2/pipeline/pipeline_stable_video_diffusion_controlnext.py
@@ -20,7 +20,7 @@ import numpy as np
 import PIL.Image
 import torch
 from transformers import CLIPImageProcessor, CLIPVisionModelWithProjection
-from models.controlnext_vid_svd import ControlNeXtSDVModel
+from models.controlnext_vid_svd import ControlNeXtSVDModel
 
 from diffusers.image_processor import VaeImageProcessor
 from diffusers.models import AutoencoderKLTemporalDecoder, UNetSpatioTemporalConditionModel
@@ -125,7 +125,7 @@ class StableVideoDiffusionPipelineControlNeXt(DiffusionPipeline):
         vae: AutoencoderKLTemporalDecoder,
         image_encoder: CLIPVisionModelWithProjection,
         unet: UNetSpatioTemporalConditionControlNeXtModel,
-        controlnext: ControlNeXtSDVModel,
+        controlnext: ControlNeXtSVDModel,
         scheduler: EulerDiscreteScheduler,
         feature_extractor: CLIPImageProcessor,
     ):

--- a/ControlNeXt-SVD-v2/run_controlnext.py
+++ b/ControlNeXt-SVD-v2/run_controlnext.py
@@ -3,7 +3,7 @@ import torch
 import numpy as np
 from PIL import Image
 from pipeline.pipeline_stable_video_diffusion_controlnext import StableVideoDiffusionPipelineControlNeXt
-from models.controlnext_vid_svd import ControlNeXtSDVModel
+from models.controlnext_vid_svd import ControlNeXtSVDModel
 from models.unet_spatio_temporal_condition_controlnext import UNetSpatioTemporalConditionControlNeXtModel
 from transformers import CLIPVisionModelWithProjection
 import re 
@@ -221,7 +221,7 @@ if __name__ == "__main__":
         subfolder="unet",
         low_cpu_mem_usage=True,
     )
-    controlnext = ControlNeXtSDVModel()
+    controlnext = ControlNeXtSVDModel()
     controlnext.load_state_dict(load_tensor(args.controlnext_path))
     unet.load_state_dict(load_tensor(args.unet_path), strict=False)
 

--- a/ControlNeXt-SVD/models/controlnext_vid_svd.py
+++ b/ControlNeXt-SVD/models/controlnext_vid_svd.py
@@ -337,7 +337,7 @@ class ControlProject(nn.Module):
     
 
 
-class ControlNeXtSDVModel(ModelMixin, ConfigMixin):
+class ControlNeXtSVDModel(ModelMixin, ConfigMixin):
 
     _supports_gradient_checkpointing = True
 

--- a/ControlNeXt-SVD/pipeline/pipeline_stable_video_diffusion_controlnext.py
+++ b/ControlNeXt-SVD/pipeline/pipeline_stable_video_diffusion_controlnext.py
@@ -20,7 +20,7 @@ import numpy as np
 import PIL.Image
 import torch
 from transformers import CLIPImageProcessor, CLIPVisionModelWithProjection
-from models.controlnext_vid_svd import ControlNeXtSDVModel
+from models.controlnext_vid_svd import ControlNeXtSVDModel
 
 from diffusers.image_processor import VaeImageProcessor
 from diffusers.models import AutoencoderKLTemporalDecoder, UNetSpatioTemporalConditionModel
@@ -125,7 +125,7 @@ class StableVideoDiffusionPipelineControlNeXt(DiffusionPipeline):
         vae: AutoencoderKLTemporalDecoder,
         image_encoder: CLIPVisionModelWithProjection,
         unet: UNetSpatioTemporalConditionControlNeXtModel,
-        controlnext: ControlNeXtSDVModel,
+        controlnext: ControlNeXtSVDModel,
         scheduler: EulerDiscreteScheduler,
         feature_extractor: CLIPImageProcessor,
     ):

--- a/ControlNeXt-SVD/run_controlnext.py
+++ b/ControlNeXt-SVD/run_controlnext.py
@@ -3,7 +3,7 @@ import torch
 import numpy as np
 from PIL import Image
 from pipeline.pipeline_stable_video_diffusion_controlnext import StableVideoDiffusionPipelineControlNeXt
-from models.controlnext_vid_svd import ControlNeXtSDVModel
+from models.controlnext_vid_svd import ControlNeXtSVDModel
 from models.unet_spatio_temporal_condition_controlnext import UNetSpatioTemporalConditionControlNeXtModel
 from transformers import CLIPVisionModelWithProjection
 import re 
@@ -202,7 +202,7 @@ if __name__ == "__main__":
         low_cpu_mem_usage=True,
         variant="fp16",
     )
-    controlnext = ControlNeXtSDVModel()
+    controlnext = ControlNeXtSVDModel()
     controlnext.load_state_dict(load_tensor(args.controlnext_path))
     unet.load_state_dict(load_tensor(args.unet_path), strict=False)
 


### PR DESCRIPTION
Hi @Randolph-zeng ,

Thanks for the great work! I found that there are typos in SVD-related codes. Specifically, the `ControlNeXtSVDModel` is defined as `ControlNeXtSDVModel`.

In this PR, all `ControlNeXtSDVModel` are fixed to `ControlNeXtSVDModel`.